### PR TITLE
Update JDK version and refactor test packages/models

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 23
+    - name: Set up JDK 24
       uses: actions/setup-java@v4
       with:
-        java-version: '23'
+        java-version: '24'
         distribution: 'temurin'
 
     - name: Setup Gradle
@@ -44,8 +44,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 23
+    - name: Set up JDK 24
       uses: actions/setup-java@v4
       with:
-        java-version: '23'
+        java-version: '24'
         distribution: 'temurin'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
-    kotlin("jvm") version "2.1.20"
+    kotlin("jvm") version "2.1.21"
 }
 
 group = "com.example"
@@ -19,6 +21,7 @@ tasks.test {
 kotlin {
     jvmToolchain(23)
     compilerOptions {
+        jvmTarget = JvmTarget.JVM_23
         javaParameters = true
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.jvmargs=-Xms512M -Xmx1G -Dfile.encoding=UTF-8 -Dconsole.encoding=UTF-
 org.gradle.configureondemand=true
 #Kotlin
 kotlin.code.style=official
-defaultKotlinVersion=2.1.20
+defaultKotlinVersion=2.1.21

--- a/src/test/kotlin/e01/BlockingCompletionsTest.kt
+++ b/src/test/kotlin/e01/BlockingCompletionsTest.kt
@@ -16,7 +16,7 @@ internal class BlockingCompletionsTest {
             .builder()
             .apiKey(TestEnvironment.get("OPENAI_API_KEY", "dummy-key-for-tests"))
             .baseUrl(mockOpenAi.baseUrl())
-            .modelName("gpt-4o-mini")
+            .modelName("gpt-4.1-nano")
             .temperature(0.7)
             .maxCompletionTokens(100)
             .logResponses(true)

--- a/src/test/kotlin/e01/JavaAsyncWrapperTest.kt
+++ b/src/test/kotlin/e01/JavaAsyncWrapperTest.kt
@@ -3,12 +3,14 @@ package e01
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
 
 class JavaAsyncWrapperTest {
-    suspend fun chatAsync(): String {
-        return withContext(Dispatchers.IO) {
+
+    suspend fun chatAsync(context: CoroutineContext = Dispatchers.IO): String {
+        return withContext(context) {
             Thread.sleep(1.seconds.inWholeMilliseconds)
             return@withContext "Hello, World"
         }

--- a/src/test/kotlin/e01/SuspendCompletionsTest.kt
+++ b/src/test/kotlin/e01/SuspendCompletionsTest.kt
@@ -19,7 +19,7 @@ internal class SuspendCompletionsTest {
             .builder()
             .apiKey(TestEnvironment.get("OPENAI_API_KEY", "dummy-key-for-tests"))
             .baseUrl(mockOpenAi.baseUrl())
-            .modelName("gpt-4o-mini")
+            .modelName("gpt-4.1-nano")
             .temperature(0.7)
             .maxCompletionTokens(100)
             .logResponses(true)

--- a/src/test/kotlin/e02parallel/ParallelCompletionsTest.kt
+++ b/src/test/kotlin/e02parallel/ParallelCompletionsTest.kt
@@ -1,4 +1,4 @@
-package e02
+package e02parallel
 
 import dev.langchain4j.data.message.UserMessage.userMessage
 import dev.langchain4j.kotlin.model.chat.chat
@@ -44,14 +44,10 @@ class ParallelCompletionsTest {
                         .map { index ->
                             async {
                                 val aiMessageText =
-                                    model
-                                        .chat {
-                                            messages(
-                                                listOf(userMessage("Concurrent request #$index")),
-                                            )
-                                        }.aiMessage()
-                                        .text()
-                                // println("Request $index finished")
+                                    model.chat {
+                                        messages += userMessage("Concurrent request #$index")
+                                    }.aiMessage().text()
+                                 println("Request $index finished")
                                 aiMessageText
                             }
                         }.awaitAll()

--- a/src/test/kotlin/e03streaming/CompletionsStreamingTest.kt
+++ b/src/test/kotlin/e03streaming/CompletionsStreamingTest.kt
@@ -1,4 +1,4 @@
-package e03
+package e03streaming
 
 import dev.langchain4j.data.message.UserMessage.userMessage
 import dev.langchain4j.model.chat.request.ChatRequest
@@ -23,7 +23,7 @@ class CompletionsStreamingTest {
             .builder()
             .apiKey(TestEnvironment.get("OPENAI_API_KEY", "dummy-key-for-tests"))
             .baseUrl(mockOpenAi.baseUrl())
-            .modelName("gpt-4o-mini")
+            .modelName("gpt-4.1-nano")
             .logResponses(true)
             .logRequests(true)
             .build()

--- a/src/test/kotlin/e03streaming/SuspendCompletionsStreamingTest.kt
+++ b/src/test/kotlin/e03streaming/SuspendCompletionsStreamingTest.kt
@@ -1,4 +1,4 @@
-package e03
+package e03streaming
 
 import dev.langchain4j.data.message.UserMessage.userMessage
 import dev.langchain4j.kotlin.model.chat.StreamingChatModelReply
@@ -22,8 +22,8 @@ class SuspendCompletionsStreamingTest {
         OpenAiStreamingChatModel
             .builder()
             .apiKey(TestEnvironment.get("OPENAI_API_KEY", "dummy-key-for-tests"))
-            .baseUrl(mockOpenAi.baseUrl())
-            .modelName("gpt-4o-mini")
+            .baseUrl(mockOpenAi.baseUrl()) // comment this to call real OpenAI
+            .modelName("gpt-4.1-nano")
             .logResponses(true)
             .logRequests(true)
             .build()

--- a/src/test/kotlin/e04/AiMocksServiceTest.kt
+++ b/src/test/kotlin/e04/AiMocksServiceTest.kt
@@ -10,11 +10,13 @@ import kotlin.test.Test
 class AiMocksServiceTest {
     val mockOpenAi = MockOpenai(verbose = true)
 
-    val model =
+    val model: OpenAiChatModel =
         OpenAiChatModel
             .builder()
             .baseUrl(mockOpenAi.baseUrl())
-            .modelName("o1")
+            .modelName("gpt-4.1-nano")
+            .logRequests(true)
+            .logResponses(true)
             .build()
 
     interface JokeService {

--- a/src/test/kotlin/e05rag/Assistant.kt
+++ b/src/test/kotlin/e05rag/Assistant.kt
@@ -1,4 +1,4 @@
-package e05
+package e05rag
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties

--- a/src/test/kotlin/e05rag/RagWithMemoryTest.kt
+++ b/src/test/kotlin/e05rag/RagWithMemoryTest.kt
@@ -1,4 +1,4 @@
-package e05
+package e05rag
 
 import dev.langchain4j.data.document.loader.FileSystemDocumentLoader
 import dev.langchain4j.data.document.parser.TextDocumentParser
@@ -44,7 +44,7 @@ class RagWithMemoryTest {
         OpenAiChatModel
             .builder()
             .apiKey(TestEnvironment.get("OPENAI_API_KEY"))
-            .modelName("gpt-4o-mini")
+            .modelName("gpt-4.1-nano")
             .maxTokens(1500)
             .responseFormat("json_schema")
             .strictJsonSchema(true)

--- a/src/test/kotlin/e06moderation/ModeratedAssistant.kt
+++ b/src/test/kotlin/e06moderation/ModeratedAssistant.kt
@@ -1,4 +1,4 @@
-package e06
+package e06moderation
 
 import dev.langchain4j.service.Moderate
 import dev.langchain4j.service.SystemMessage

--- a/src/test/kotlin/e06moderation/ModerationTest.kt
+++ b/src/test/kotlin/e06moderation/ModerationTest.kt
@@ -1,4 +1,4 @@
-package e06
+package e06moderation
 
 import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiModerationModel
@@ -19,7 +19,7 @@ class ModerationTest {
         OpenAiChatModel
             .builder()
             .apiKey(TestEnvironment["OPENAI_API_KEY"])
-            .modelName("gpt-4o-mini")
+            .modelName("gpt-4.1-nano")
             .maxTokens(100)
             .logRequests(true)
             .logResponses(true)


### PR DESCRIPTION
- Upgraded JDK from version 23 to 24 in the GitHub Actions workflow. 
- Refactored test package structure for better clarity and updated OpenAI model references from "gpt-4o-mini" to "gpt-4.1-nano". 
- Minor code optimizations and enhancements were also made across various tests.
- Upgrade kotlin to 2.1.21
